### PR TITLE
Bump pyo to 0.10.1 due to removed feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "bip39"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.9.2"
+version = "0.10.1"
 features = ["extension-module"]
 
 [package.metadata.maturin]


### PR DESCRIPTION
When compiling on latest rust nightly and stable, this was broken due to some feature gates being changed. This seems to work fine with a slight bump for pyo. (bump to 13.x not possible due to pyo api changes)
So far tested mostly on arm but should be similar for other archs.