### PR TITLE
Added multi-language support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "py-bip39-bindings"
 description = "Python bindings for tiny-bip39 RUST crate"
 authors=["Stichting Polkascan (Polkascan Foundation)"]
-version = "0.1.8"
+version = "0.1.9"
 repository = "https://github.com/polkascan/py-bip39-bindings"
 homepage = "https://github.com/polkascan/py-bip39-bindings"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ edition = "2018"
 [dependencies]
 hmac = "0.7.0"
 pbkdf2 = { version = "0.3.0", default-features = false }
-sha2 = "0.8.0"
-tiny-bip39 = { version = "0.6.2", default-features = false }
+sha2 = "0.8.2"
+tiny-bip39 = { version = "0.8.2", default-features = true }
 
 [lib]
 name = "bip39"
@@ -34,5 +34,6 @@ classifier = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9"
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10"
 ]

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ pip install py-bip39-bindings
 pip install -r requirements.txt
 maturin develop
 ```
-### Build wheelhouses
+### Build wheels
 ```shell script
 pip install -r requirements.txt
 
-# Build local OS wheelhouse
+# Build local OS wheel
 maturin build
 
-# Build manylinux1 wheelhouse
+# Build manylinux1 wheel
 docker build . --tag polkasource/maturin
 docker run --rm -i -v $(pwd):/io polkasource/maturin build
 
@@ -47,6 +47,23 @@ seed_array = bip39_to_mini_secret(mnemonic, "")
 seed_hex = binascii.hexlify(bytearray(seed_array)).decode("ascii")
 
 ```
+
+## Multi-language support
+
+The following language codes are supported: 'en', 'zh-hans', 'zh-hant', 'fr', 'it', 'jap', 'ko', 'es'. Defaults to 'en'
+
+```python
+mnemonic = bip39_generate(12, 'fr')
+# 'moufle veinard tronc magasin merle amour toboggan admettre biotype décembre régalien billard'
+bip39_validate(mnemonic, 'fr')
+
+seed_array = bip39_to_mini_secret(mnemonic, "", 'fr')
+
+mnemonic = bip39_generate(12, 'zh-hans')
+# '观 敲 荣 硬 责 雪 专 宴 醇 飞 图 菌'
+```
+
+
 
 ## License
 https://github.com/polkascan/py-bip39-bindings/blob/master/LICENSE

--- a/tests.py
+++ b/tests.py
@@ -32,7 +32,7 @@ class MyTestCase(unittest.TestCase):
 
     def test_generate_mnemonic_french(self):
         mnemonic = bip39.bip39_generate(12, 'fr')
-        self.assertTrue(bip39.bip39_validate(mnemonic))
+        self.assertTrue(bip39.bip39_validate(mnemonic, 'fr'))
 
     def test_generate_invalid_mnemonic(self):
         self.assertRaises(ValueError, bip39.bip39_generate, 13)

--- a/tests.py
+++ b/tests.py
@@ -30,11 +30,23 @@ class MyTestCase(unittest.TestCase):
         mnemonic = bip39.bip39_generate(12)
         self.assertTrue(bip39.bip39_validate(mnemonic))
 
+    def test_generate_mnemonic_french(self):
+        mnemonic = bip39.bip39_generate(12, 'fr')
+        self.assertTrue(bip39.bip39_validate(mnemonic))
+
     def test_generate_invalid_mnemonic(self):
         self.assertRaises(ValueError, bip39.bip39_generate, 13)
 
     def test_validate_mnemonic(self):
         self.assertTrue(bip39.bip39_validate(self.mnemonic))
+
+    def test_validate_mnemonic_zh_hans(self):
+        self.assertTrue(bip39.bip39_validate('观 敲 荣 硬 责 雪 专 宴 醇 飞 图 菌', 'zh-hans'))
+
+    def test_validate_mnemonic_fr(self):
+        self.assertTrue(bip39.bip39_validate(
+            'moufle veinard tronc magasin merle amour toboggan admettre biotype décembre régalien billard', 'fr'
+        ))
 
     def test_invalidate_mnemonic(self):
         self.assertFalse(bip39.bip39_validate("invalid mnemonic"))
@@ -42,14 +54,45 @@ class MyTestCase(unittest.TestCase):
     def test_mini_seed(self):
         self.assertEqual(self.mini_secret, bip39.bip39_to_mini_secret(self.mnemonic, ''))
 
+    def test_mini_seed_zh_hans(self):
+
+        mini_secret = bip39.bip39_to_mini_secret('观 敲 荣 硬 责 雪 专 宴 醇 飞 图 菌', '', 'zh-hans')
+        self.assertEqual(
+            [60, 215, 169, 79, 32, 218, 203, 59, 53, 155, 18, 234, 160, 215, 97, 30, 176, 243, 224, 103, 240, 114, 170,
+             26, 4, 63, 250, 164, 88, 148, 41, 68], mini_secret)
+
     def test_invalid_mini_seed(self):
         self.assertRaises(ValueError, bip39.bip39_to_mini_secret, 'invalid mnemonic', '')
 
     def test_seed(self):
         self.assertEqual(self.seed, bip39.bip39_to_seed(self.mnemonic, ''))
 
+    def test_seed_zh_hans(self):
+        mnemonic = '旅 滨 昂 园 扎 点 郎 能 指 死 爬 根'
+        seed = bip39.bip39_to_seed(mnemonic, '', 'zh-hans')
+
+        self.assertEqual(
+            '3e349679fd7fb457810d578a8b63237c6ba1fd09b39d7f33650c0f879a2cdc46',
+            bytes(seed).hex()
+        )
+
+    def test_seed_fr(self):
+        mnemonic = 'moufle veinard tronc magasin merle amour toboggan admettre biotype décembre régalien billard'
+        seed = bip39.bip39_to_seed(mnemonic, '', 'fr')
+
+        self.assertEqual(
+            'fe7ca72e2de46c24f121cf649057202ffdd9a51e63fc9fd98f8614fc68c6bbff',
+            bytes(seed).hex()
+        )
+
     def test_invalid_seed(self):
         self.assertRaises(ValueError, bip39.bip39_to_seed, 'invalid mnemonic', '')
+
+    def test_invalid_language_code(self):
+        with self.assertRaises(ValueError) as e:
+            bip39.bip39_generate(12, "unknown")
+
+        self.assertEqual('Invalid language_code', str(e.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added support for the following language codes: 'en', 'zh-hans', 'zh-hant', 'fr', 'it', 'jap', 'ko', 'es'. Defaults to 'en'

Closes #6 