### PR TITLE
wheels musllinux

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -134,11 +134,176 @@ jobs:
           name: wheels
           path: dist
 
+  build_wheels_x86_64:
+    name: Build musl wheels on x86_64
+    runs-on: ubuntu-latest
+
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y"
+      CIBW_BEFORE_BUILD: "pip3 install 'maturin>=0.10,<0.11'"
+      CIBW_ARCHS_LINUX: "auto64"
+      CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
+      CIBW_BUILD: "*-musllinux_x86_64"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* cp37-*"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: add additional package
+        run: sudo apt-get install patchelf
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.9.0
+        with:
+          output-dir: dist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+  build_wheels_python38:
+    name: Build wheels on aarch64 for python3.8
+    runs-on: ubuntu-latest
+
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y"
+      CIBW_ARCHS_LINUX: "aarch64"
+      CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
+      CIBW_BUILD: "cp38-musllinux_aarch64"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* cp37-*"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: add additional package
+        run: sudo apt-get install patchelf
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.9.0
+        with:
+          output-dir: dist
+
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+  build_wheels_python39:
+    name: Build wheels on aarch64 for python3.9
+    runs-on: ubuntu-latest
+
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y"
+      CIBW_ARCHS_LINUX: "aarch64"
+      CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
+      CIBW_BUILD: "cp39-musllinux_aarch64"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* cp37-*"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: add additional package
+        run: sudo apt-get install patchelf
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.9.0
+        with:
+          output-dir: dist
+
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+  build_wheels_python310:
+    name: Build wheels on aarch64 for python3.10
+    runs-on: ubuntu-latest
+
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y"
+      CIBW_ARCHS_LINUX: "aarch64"
+      CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
+      CIBW_BUILD: "cp310-musllinux_aarch64"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* cp37-*"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: add additional package
+        run: sudo apt-get install patchelf
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.9.0
+        with:
+          output-dir: dist
+
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+  build_wheels_python311:
+    name: Build wheels on aarch64 for python3.11
+    runs-on: ubuntu-latest
+
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y"
+      CIBW_ARCHS_LINUX: "aarch64"
+      CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
+      CIBW_BUILD: "cp311-musllinux_aarch64"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* cp37-*"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: add additional package
+        run: sudo apt-get install patchelf
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.9.0
+        with:
+          output-dir: dist
+
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
   release:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [ macos, windows, linux ]
+    needs: [ macos, windows, linux, build_wheels_x86_64, build_wheels_python38, build_wheels_python39, build_wheels_python310, build_wheels_python311]
     steps:
       - uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
Hi, it's me again. You have recently created wheels for aarch64 platform. Especially, for `manylinux`  systems. But I'm working with Home Assistant OS and it is `musllinux` system. So, all generated wheels are unsuitable for this system.

I really need this wheels,because otherwise my HA integrations doesn't work property. I've decided to create github action for it. Also, I've integrated this action in your github action for PyPi.Wheels already tested on RPi4 with HomeAssistant OS and everything is working. 

Please, add this wheels to Pypi. 
If any questions, fill free to ask.